### PR TITLE
Fix addon.xml

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
     id="plugin.video.hdtrailers_net.reloaded"


### PR DESCRIPTION
The newline at the beginning of the `addon.xml` is technically invalid XML. I only found it when a bug was reported on an add-on which does operations on these XML files, but that would fix it.